### PR TITLE
Prefix all log lines with the process name

### DIFF
--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -19,7 +19,9 @@ def main():
 def event_handler(event, response):
     line, data = response.split('\n', 1)
     headers = dict([ x.split(':') for x in line.split() ])
-    print '%s %s | %s'%(headers['processname'], headers['channel'], data),
+    lines = data.split('\n')
+    prefix = '%s %s | '%(headers['processname'], headers['channel'])
+    print '\n'.join([ prefix + l for l in lines ])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
To be able to process the output of this plugin, it is much better if we can assume that all output lines are prefixed with the process name and channel.