### PR TITLE
Spurious empty lines in log

### DIFF
--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -19,7 +19,7 @@ def main():
 def event_handler(event, response):
     line, data = response.split('\n', 1)
     headers = dict([ x.split(':') for x in line.split() ])
-    lines = data.split('\n')
+    lines = data.splitlines()
     prefix = '%s %s | '%(headers['processname'], headers['channel'])
     print '\n'.join([ prefix + l for l in lines ])
 


### PR DESCRIPTION
Not sure if it's the same issue of #11, but each time the event handler was called with a bunch of lines to log, it added a new empty line because split('\n') returns a leading empty string when the input ends with a newline.
