### PR TITLE
Add python 3 compatibility, bump version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name = 'supervisor-stdout',
-    version = '0.1.1',
+    version = '0.2.0',
     py_modules = ['supervisor_stdout'],
 
     author = 'Noah Kantrowitz',

--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 
 def write_stdout(s):
@@ -21,7 +22,7 @@ def event_handler(event, response):
     headers = dict([ x.split(':') for x in line.split() ])
     lines = data.split('\n')
     prefix = '%s %s | '%(headers['processname'], headers['channel'])
-    print '\n'.join([ prefix + l for l in lines ])
+    print('\n'.join([ prefix + l for l in lines ]))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR adds python 3 compatibility by adding parentheses around the print function. Note that since we have ```from __future__ import print_function```, this makes the minimum Python version at least 2.6 now. (This shouldn't be a problem these days.)

This adds a MANIFEST.in to include README.md to that installing from an archive created via "python setup.py sdist" works properly (the setup.py refers to README.md which is not packaged by default in a sdist)

This also bumps the version. If possible, please publish a new PyPI release; the latest one even is missing the PR for prefixing with process name.