### PR TITLE
Fix length calculation in protocol

### DIFF
--- a/supervisor_stdout.py
+++ b/supervisor_stdout.py
@@ -15,7 +15,7 @@ def main():
         line = sys.stdin.readline()  # read header line from stdin
         headers = dict([ x.split(':') for x in line.split() ])
         data = sys.stdin.read(int(headers['len'])) # read the event payload
-        write_stdout('RESULT %s\n%s'%(len(data), data)) # transition from READY to ACKNOWLEDGED
+        write_stdout('RESULT %s\n%s'%(len(data.encode("utf-8")), data)) # transition from READY to ACKNOWLEDGED
 
 def event_handler(event, response):
     line, data = response.split('\n', 1)


### PR DESCRIPTION
The data is read as bytes, to the length in the response needs to be
calculated in bytes and not in chars.

Inspired by https://github.com/quay/supervisor-stdout/commit/9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380